### PR TITLE
Resource definition should be `schema.TypeSet`

### DIFF
--- a/namecheap/resource_domain_dns.go
+++ b/namecheap/resource_domain_dns.go
@@ -22,7 +22,7 @@ func resourceDomainDNS() *schema.Resource {
 			},
 			"nameservers": {
 				Description: "List of custom nameservers to be associated with the domain name",
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Required:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},


### PR DESCRIPTION
There is an incompatibility between the Type definition of the resource parameter and the implementation.

This results in an error when

```
Stack trace from the terraform-provider-namecheap_v0.1.6 plugin:

panic: interface conversion: interface {} is []interface {}, not *schema.Set


github.com/Namecheap-Ecosystem/terraform-provider-namecheap/namecheap.resourceDomainDNSUpdate(0x19a8300, 0xc00070c900, 0xc00064a300, 0x189c740, 0xc00009cc00, 0xc000679510, 0x1479e6a, 0xc00000cb80)
	github.com/Namecheap-Ecosystem/terraform-provider-namecheap/namecheap/resource_domain_dns.go:76 +0x398
<snip>
```

Changing from `schema.TypeList` to `schema.TypeSet` solves this problem.
